### PR TITLE
fix(WorldClock): 修复passedTime计算为负值时this.time偏移正负号错误

### DIFF
--- a/DragonBones/src/dragonBones/animation/WorldClock.ts
+++ b/DragonBones/src/dragonBones/animation/WorldClock.ts
@@ -102,20 +102,16 @@ namespace dragonBones {
                 passedTime = 0.0;
             }
 
+            let currentTime = new Date().getTime();
             if (passedTime < 0.0) {
-                passedTime = new Date().getTime() * 0.001 - this.time;
+                passedTime = currentTime * 0.001 - this.time;
             }
 
             if (this.timeScale !== 1.0) {
                 passedTime *= this.timeScale;
             }
 
-            if (passedTime < 0.0) {
-                this.time += passedTime;
-            }
-            else {
-                this.time += passedTime;
-            }
+            this.time = currentTime;
 
             if (passedTime === 0.0) {
                 return;

--- a/DragonBones/src/dragonBones/animation/WorldClock.ts
+++ b/DragonBones/src/dragonBones/animation/WorldClock.ts
@@ -111,7 +111,7 @@ namespace dragonBones {
             }
 
             if (passedTime < 0.0) {
-                this.time -= passedTime;
+                this.time += passedTime;
             }
             else {
                 this.time += passedTime;


### PR DESCRIPTION
see #53 

one solution is fix incorrect process of `this.time` when `passedTime < 0`. but the inner process is not such robust that maybe other triggers/conditions caused same error result.