### PR TITLE
Phaser 3 - load assets into cache instead directly into factory

### DIFF
--- a/Phaser/3.x/src/dragonBones/phaser/plugin/DragonBonesFile.ts
+++ b/Phaser/3.x/src/dragonBones/phaser/plugin/DragonBonesFile.ts
@@ -75,17 +75,24 @@ namespace dragonBones.phaser.plugin {
 
         addToCache(): void {
             if (this.isReadyToProcess()) {
+                const binaryParser = new BinaryDataParser();
+
                 const image = this.files[0];
                 const json = this.files[1];
                 const bone = this.files[2];
 
-                const dbPlugin = this.loader.scene["dragonbone"];
-                if (!dbPlugin)
-                    throw new Error("Please add the dragonbone plugin in your GameConfig");
+                const cacheItem:Phaser.Cache.BaseCache = this.loader["cacheManager"].addCustom("dragonbones");
 
-                const db = dbPlugin.factory.parseDragonBonesData(bone.data, bone.key, this._scale);
-                db.name = image.key;
-                dbPlugin.factory.parseTextureAtlasData(json.data, image.data, image.key, this._scale);
+                const dragonBonesData = binaryParser.parseDragonBonesData(bone.data, this._scale);
+
+                const cacheObject:util.CacheItem = {
+                    boneData: dragonBonesData,
+                    scale: this._scale,
+                    textureData: json.data,
+                    textureImage: image.data,
+                    textureImageKey: image.key
+                }
+                cacheItem.add(bone.key, cacheObject);
 
                 this.complete = true;
             }

--- a/Phaser/3.x/src/dragonBones/phaser/util/CacheItem.ts
+++ b/Phaser/3.x/src/dragonBones/phaser/util/CacheItem.ts
@@ -1,0 +1,9 @@
+namespace dragonBones.phaser.util {
+    export class CacheItem {
+        boneData:DragonBonesData;
+        scale:number;
+        textureData:any;
+        textureImage:any;
+        textureImageKey:string;
+    }
+}

--- a/Phaser/3.x/tsconfig.json
+++ b/Phaser/3.x/tsconfig.json
@@ -71,6 +71,7 @@
 		"./src/dragonBones/phaser/util/EventDispatcher.ts",
 		"./src/dragonBones/phaser/util/SkewComponent.ts",
 		"./src/dragonBones/phaser/util/TransformMatrix.ts",
+		"./src/dragonBones/phaser/util/CacheItem.ts",
 		"./src/dragonBones/phaser/display/DisplayContainer.ts",
 		"./src/dragonBones/phaser/display/ArmatureDisplay.ts",
 		"./src/dragonBones/phaser/display/SlotImage.ts",


### PR DESCRIPTION
This solves the problem when you want to load dragonbones assets in different scene than to use them in. Phaser 3 has Cache store exactly for this purpose, this uses it.

It has one problem, when you use the asset first time, it is not found in the factory instance and warning is printed into console, than if the resource is in cache, it is loaded. There is no simple way to suppress this warning, only to check if the asset is in factory before trying to load it which will result in searching for it twice.