### PR TITLE
添加`useSharedTicker`参数, 以及 静态的公共方法`advanceTime(passedTime)`

### DIFF
--- a/Pixi/4.x/src/dragonBones/pixi/PixiFactory.ts
+++ b/Pixi/4.x/src/dragonBones/pixi/PixiFactory.ts
@@ -39,8 +39,11 @@ namespace dragonBones {
             this._dragonBonesInstance.advanceTime(PIXI.ticker.shared.elapsedMS * passedTime * 0.001);
         }
 
-        public static tick(elapsedSec: number): void {
-            this._dragonBonesInstance.advanceTime(elapsedSec);
+        /*
+         * `passedTime` is elapsed time, specified in seconds.
+         */
+        public static advanceTime(passedTime: number): void {
+            this._dragonBonesInstance.advanceTime(passedTime);
         }
 
         /**

--- a/Pixi/4.x/src/dragonBones/pixi/PixiFactory.ts
+++ b/Pixi/4.x/src/dragonBones/pixi/PixiFactory.ts
@@ -9,10 +9,10 @@
  * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
  * the Software, and to permit persons to whom the Software is furnished to do so,
  * subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
  * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -39,8 +39,8 @@ namespace dragonBones {
             this._dragonBonesInstance.advanceTime(PIXI.ticker.shared.elapsedMS * passedTime * 0.001);
         }
 
-        public static clockHandler(passedTime: number): void {
-            this._dragonBonesInstance.advanceTime(passedTime * 0.001);
+        public static tick(elapsedSec: number): void {
+            this._dragonBonesInstance.advanceTime(elapsedSec);
         }
 
         /**

--- a/Pixi/4.x/src/dragonBones/pixi/PixiFactory.ts
+++ b/Pixi/4.x/src/dragonBones/pixi/PixiFactory.ts
@@ -38,6 +38,11 @@ namespace dragonBones {
         private static _clockHandler(passedTime: number): void {
             this._dragonBonesInstance.advanceTime(PIXI.ticker.shared.elapsedMS * passedTime * 0.001);
         }
+
+        public static clockHandler(passedTime: number): void {
+            this._dragonBonesInstance.advanceTime(passedTime * 0.001);
+        }
+
         /**
          * - A global factory instance that can be used directly.
          * @version DragonBones 4.7
@@ -58,13 +63,15 @@ namespace dragonBones {
         /**
          * @inheritDoc
          */
-        public constructor(dataParser: DataParser | null = null) {
+        public constructor(dataParser: DataParser | null = null, useSharedTicker = true) {
             super(dataParser);
 
             if (PixiFactory._dragonBonesInstance === null) {
                 const eventManager = new PixiArmatureDisplay();
                 PixiFactory._dragonBonesInstance = new DragonBones(eventManager);
-                PIXI.ticker.shared.add(PixiFactory._clockHandler, PixiFactory);
+                if (useSharedTicker) {
+                    PIXI.ticker.shared.add(PixiFactory._clockHandler, PixiFactory);
+                }
             }
 
             this._dragonBones = PixiFactory._dragonBonesInstance;


### PR DESCRIPTION
其实在实际项目中,  大多数 Pixi的用户 并不会使用 PIXI.ticker.shared , 而且 PIXI的ticker设计的其实并不好.
所以 这个PR 为DragonBonesJS pixi版本增加了 是否使用 PIXI.ticker.shared 的参数.
而且参数默认值 是 true, 所以这个改变并不会影响现有的项目.