### PR TITLE
添加`useSharedTicker`参数, 以及 静态的公共方法`advanceTime(passedTime)`

### DIFF
--- a/Pixi/4.x/src/dragonBones/pixi/PixiFactory.ts
+++ b/Pixi/4.x/src/dragonBones/pixi/PixiFactory.ts
@@ -9,10 +9,10 @@
  * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
  * the Software, and to permit persons to whom the Software is furnished to do so,
  * subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
  * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -38,6 +38,19 @@ namespace dragonBones {
         private static _clockHandler(passedTime: number): void {
             this._dragonBonesInstance.advanceTime(PIXI.ticker.shared.elapsedMS * passedTime * 0.001);
         }
+
+        /*
+         * `passedTime` is elapsed time, specified in seconds.
+         */
+        public static advanceTime(passedTime: number): void {
+            this._dragonBonesInstance.advanceTime(passedTime);
+        }
+
+        /*
+        * whether use `PIXI.ticker.shared`
+        */
+        public static useSharedTicker: boolean = true;
+
         /**
          * - A global factory instance that can be used directly.
          * @version DragonBones 4.7
@@ -50,7 +63,7 @@ namespace dragonBones {
          */
         public static get factory(): PixiFactory {
             if (PixiFactory._factory === null) {
-                PixiFactory._factory = new PixiFactory();
+                PixiFactory._factory = new PixiFactory(null, PixiFactory.useSharedTicker);
             }
 
             return PixiFactory._factory;
@@ -58,13 +71,15 @@ namespace dragonBones {
         /**
          * @inheritDoc
          */
-        public constructor(dataParser: DataParser | null = null) {
+        public constructor(dataParser: DataParser | null = null, useSharedTicker = true) {
             super(dataParser);
 
             if (PixiFactory._dragonBonesInstance === null) {
                 const eventManager = new PixiArmatureDisplay();
                 PixiFactory._dragonBonesInstance = new DragonBones(eventManager);
-                PIXI.ticker.shared.add(PixiFactory._clockHandler, PixiFactory);
+                if (useSharedTicker) {
+                    PIXI.ticker.shared.add(PixiFactory._clockHandler, PixiFactory);
+                }
             }
 
             this._dragonBones = PixiFactory._dragonBonesInstance;


### PR DESCRIPTION
其实在实际项目中, 大多数 Pixi的用户 并不会使用 PIXI.ticker.shared , 而且 PIXI的ticker设计的并不好.

所以 这个PR 为DragonBonesJS pixi版本增加了 是否使用 PIXI.ticker.shared 的参数.

参数默认值 是 true, 所以这个改变并不会影响现有的项目.

用法: 
```
    dragonBones.PixiFactory.useSharedTicker = false;
    var factory = dragonBones.PixiFactory.factory;

     // 此时 不会使用 PIXI.ticker.shared

    //   用户可以在 自己的 game loop 函数里使用 下面的方法来更新动画
    dragonBones.PixiFactory.advanceTime(passedTime);
```