### PR TITLE
Fix type error, assigning Int16 to Uint16 colors

### DIFF
--- a/DragonBones/src/dragonBones/model/DragonBonesData.ts
+++ b/DragonBones/src/dragonBones/model/DragonBonesData.ts
@@ -112,7 +112,7 @@ namespace dragonBones {
         /**
          * @internal
          */
-        public intArray: Int16Array;
+        public intArray: Uint16Array;
         /**
          * @internal
          */

--- a/DragonBones/src/dragonBones/parser/BinaryDataParser.ts
+++ b/DragonBones/src/dragonBones/parser/BinaryDataParser.ts
@@ -27,7 +27,7 @@ namespace dragonBones {
     export class BinaryDataParser extends ObjectDataParser {
         private _binaryOffset: number;
         private _binary: ArrayBuffer;
-        private _intArrayBuffer: Int16Array;
+        private _intArrayBuffer: Uint16Array;
         private _frameArrayBuffer: Int16Array;
         private _timelineArrayBuffer: Uint16Array;
 
@@ -366,13 +366,13 @@ namespace dragonBones {
             const l5 = offsets[9];
             const l6 = offsets[11];
             const l7 = offsets.length > 12 ? offsets[13] : 0; // Color.
-            const intArray = new Int16Array(this._binary, this._binaryOffset + offsets[0], l1 / Int16Array.BYTES_PER_ELEMENT);
+            const intArray = new Uint16Array(this._binary, this._binaryOffset + offsets[0], l1 / Uint16Array.BYTES_PER_ELEMENT);
             const floatArray = new Float32Array(this._binary, this._binaryOffset + offsets[2], l2 / Float32Array.BYTES_PER_ELEMENT);
             const frameIntArray = new Int16Array(this._binary, this._binaryOffset + offsets[4], l3 / Int16Array.BYTES_PER_ELEMENT);
             const frameFloatArray = new Float32Array(this._binary, this._binaryOffset + offsets[6], l4 / Float32Array.BYTES_PER_ELEMENT);
             const frameArray = new Int16Array(this._binary, this._binaryOffset + offsets[8], l5 / Int16Array.BYTES_PER_ELEMENT);
             const timelineArray = new Uint16Array(this._binary, this._binaryOffset + offsets[10], l6 / Uint16Array.BYTES_PER_ELEMENT);
-            const colorArray = l7 > 0 ? new Int16Array(this._binary, this._binaryOffset + offsets[12], l7 / Int16Array.BYTES_PER_ELEMENT) : intArray; // Color.
+            const colorArray = l7 > 0 ? new Uint16Array(this._binary, this._binaryOffset + offsets[12], l7 / Uint16Array.BYTES_PER_ELEMENT) : intArray; // Color.
 
             this._data.binary = this._binary;
             this._data.intArray = this._intArrayBuffer = intArray;

--- a/DragonBones/src/dragonBones/parser/ObjectDataParser.ts
+++ b/DragonBones/src/dragonBones/parser/ObjectDataParser.ts
@@ -2244,13 +2244,13 @@ namespace dragonBones {
             const lTotal = l1 + l2 + l3 + l4 + l5 + l6 + l7;
             //
             const binary = new ArrayBuffer(lTotal);
-            const intArray = new Int16Array(binary, 0, this._intArray.length);
+            const intArray = new Uint16Array(binary, 0, this._intArray.length);
             const floatArray = new Float32Array(binary, l1, this._floatArray.length);
             const frameIntArray = new Int16Array(binary, l1 + l2, this._frameIntArray.length);
             const frameFloatArray = new Float32Array(binary, l1 + l2 + l3, this._frameFloatArray.length);
             const frameArray = new Int16Array(binary, l1 + l2 + l3 + l4, this._frameArray.length);
             const timelineArray = new Uint16Array(binary, l1 + l2 + l3 + l4 + l5, this._timelineArray.length);
-            const colorArray = new Int16Array(binary, l1 + l2 + l3 + l4 + l5 + l6, this._colorArray.length);
+            const colorArray = new Uint16Array(binary, l1 + l2 + l3 + l4 + l5 + l6, this._colorArray.length);
 
             for (let i = 0, l = this._intArray.length; i < l; ++i) {
                 intArray[i] = this._intArray[i];


### PR DESCRIPTION
I got a type error from Typescript:

```
ERROR in /app/node_modules/dragonbones-runtime/DragonBones/src/dragonBones/parser/BinaryDataParser.ts
[tsl] ERROR in /app/node_modules/dragonbones-runtime/DragonBones/src/dragonBones/parser/BinaryDataParser.ts(384,13)
      TS2322: Type 'Int16Array' is not assignable to type 'Uint16Array'.
  Types of property '[Symbol.toStringTag]' are incompatible.
    Type '"Int16Array"' is not assignable to type '"Uint16Array"'.

ERROR in /app/node_modules/dragonbones-runtime/DragonBones/src/dragonBones/parser/ObjectDataParser.ts
[tsl] ERROR in /app/node_modules/dragonbones-runtime/DragonBones/src/dragonBones/parser/ObjectDataParser.ts(2290,13)
      TS2322: Type 'Int16Array' is not assignable to type 'Uint16Array'.
```

When checking the source code, I can see:

``` ts
public colorArray: Uint16Array;
```

The unsigned type seems fine for a color representation, but later in the code, it is trying to assign a signed integer to this color attribute.

This PR fixes these errors by using unsigned integers when working with colors.

Note: A quick hack was to change `colorArray` to a signed type, this only diff is clearing errors, but not sure if it is a good solution.