### PR TITLE
使用tint替代color filter

### DIFF
--- a/DragonBones/src/dragonBones/factory/BaseFactory.ts
+++ b/DragonBones/src/dragonBones/factory/BaseFactory.ts
@@ -698,7 +698,7 @@ namespace dragonBones {
          * @version DragonBones 3.0
          * @language zh_CN
          */
-        public buildArmature(armatureName: string, dragonBonesName: string = "", skinName: string = "", textureAtlasName: string = ""): Armature | null {
+        public buildArmature(armatureName: string, dragonBonesName: string = "", skinName: string = "", textureAtlasName: string = "", isUseTint: boolean = false): Armature | null {
             const dataPackage: BuildArmaturePackage = new BuildArmaturePackage();
             if (!this._fillBuildArmaturePackage(dataPackage, dragonBonesName || "", armatureName, skinName || "", textureAtlasName || "")) {
                 console.warn("No armature data: " + armatureName + ", " + (dragonBonesName !== null ? dragonBonesName : ""));
@@ -706,6 +706,7 @@ namespace dragonBones {
             }
 
             const armature = this._buildArmature(dataPackage);
+            armature.display.isUseTint = isUseTint;
             this._buildBones(dataPackage, armature);
             this._buildSlots(dataPackage, armature);
             this._buildConstraints(dataPackage, armature);

--- a/Egret/4.x/src/dragonBones/egret/EgretArmatureDisplay.ts
+++ b/Egret/4.x/src/dragonBones/egret/EgretArmatureDisplay.ts
@@ -55,6 +55,15 @@ namespace dragonBones {
     export class EgretArmatureDisplay extends egret.DisplayObjectContainer implements IArmatureProxy {
         private static _cleanBeforeRender(): void { }
         /**
+         * Whether to use tint instead of color filter
+         * @language en_US
+         */
+        /**
+         * 是否使用 tint 优化 color filter
+         * @language zh_CN
+         */
+        public isUseTint: boolean = false;
+        /**
          * @private
          */
         public debugDraw: boolean = false;

--- a/Egret/4.x/src/dragonBones/egret/EgretFactory.ts
+++ b/Egret/4.x/src/dragonBones/egret/EgretFactory.ts
@@ -168,8 +168,8 @@ namespace dragonBones {
          * </pre>
          * @language zh_CN
          */
-        public buildArmatureDisplay(armatureName: string, dragonBonesName: string = "", skinName: string = "", textureAtlasName: string = ""): EgretArmatureDisplay | null {
-            const armature = this.buildArmature(armatureName, dragonBonesName || "", skinName || "", textureAtlasName || "");
+        public buildArmatureDisplay(armatureName: string, dragonBonesName: string = "", skinName: string = "", textureAtlasName: string = "", isUseTint: boolean = false): EgretArmatureDisplay | null {
+            const armature = this.buildArmature(armatureName, dragonBonesName || "", skinName || "", textureAtlasName || "", isUseTint);
             if (armature !== null) {
                 this._dragonBones.clock.add(armature);
 

--- a/Egret/4.x/src/dragonBones/egret/EgretSlot.ts
+++ b/Egret/4.x/src/dragonBones/egret/EgretSlot.ts
@@ -219,6 +219,33 @@ namespace dragonBones {
                 this._colorTransform.blueOffset !== 0 ||
                 this._colorTransform.alphaOffset !== 0
             ) {
+                if (
+                    this._armatureDisplay.isUseTint &&
+                    this._colorTransform.redOffset === 0 &&
+                    this._colorTransform.greenOffset === 0 &&
+                    this._colorTransform.blueOffset === 0 &&
+                    this._colorTransform.alphaOffset === 0
+                ) {
+                    // 当不使用offset时，可以用 tint+alpha 代替 filter
+                    const red = (this._colorTransform.redMultiplier * 0xFF + 0.5 | 0) << 16;
+                    const green = (this._colorTransform.greenMultiplier * 0xFF + 0.5 | 0) << 8;
+                    const blue = this._colorTransform.blueMultiplier * 0xFF + 0.5 | 0;
+                    const tintColor = red + green + blue;
+                    if (this._armatureDisplay._batchEnabled) {
+                        const node = this._renderDisplay.$renderNode as (egret.sys.BitmapNode);
+                        if ('tint' in node) {
+                            // 需要egret引擎BitmapNode与MeshNode支持tint属性
+                            node.tint = tintColor;
+                            node.alpha = alpha;
+                            return;
+                        }
+                    } else {
+                        this._renderDisplay.tint = tintColor;
+                        this._renderDisplay.alpha = alpha;
+                        return;
+                    }
+                }
+
                 if (this._colorFilter === null) {
                     this._colorFilter = new egret.ColorMatrixFilter();
                 }
@@ -257,10 +284,12 @@ namespace dragonBones {
                     const node = this._renderDisplay.$renderNode as (egret.sys.BitmapNode);
                     node.filter = null as any;
                     node.alpha = alpha;
+                    if ('tint' in node) node.tint = 0xFFFFFF;
                 }
 
                 this._renderDisplay.filters = null as any;
                 this._renderDisplay.alpha = alpha;
+                this._renderDisplay.tint = 0xFFFFFF;
             }
         }
 


### PR DESCRIPTION
观察到使用color filter时，若没有使用offset，其效果与使用tint是一样的；
而使用tint可以有效减少drawcall;
当前的修改方法还需要egret引擎同步让BitmapNode与MeshNOde支持tint属性；